### PR TITLE
header backbtn navigation

### DIFF
--- a/studioactions/common/AS_FlexContainer_cfcb9117e5864a23aa3148cb4a784eed.js
+++ b/studioactions/common/AS_FlexContainer_cfcb9117e5864a23aa3148cb4a784eed.js
@@ -1,4 +1,4 @@
 function AS_FlexContainer_cfcb9117e5864a23aa3148cb4a784eed(eventobject) {
     var self = this;
-    return self.navToLogin.call(this);
+    return self.navToPrevious.call(this);
 }

--- a/studioactions/common/AS_FlexContainer_cfcb9117e5864a23aa3148cb4a784eed.json
+++ b/studioactions/common/AS_FlexContainer_cfcb9117e5864a23aa3148cb4a784eed.json
@@ -15,8 +15,8 @@
         "actions": [{
             "id": "INVOKE_FUNCTION___d8c62b1877cb4f7089e22b9959ecbaee",
             "type": "INVOKE_FUNCTION",
-            "sequenceKUID": "navToLogin",
-            "display": "navToLogin",
+            "sequenceKUID": "navToPrevious",
+            "display": "navToPrevious",
             "inputparams": [],
             "parentId": null,
             "callbackType": null,

--- a/userwidgets/Twitter.topHeader/modules/require/topHeaderController.js
+++ b/userwidgets/Twitter.topHeader/modules/require/topHeaderController.js
@@ -10,8 +10,8 @@ define(function() {
 		},
       
       
-      navToLogin: function () {
-        let nav = kony.mvc.Navigation('LoginForm');
+      navToPrevious: function () {
+        let nav = new kony.mvc.Navigation(kony.application.getPreviousForm().id);
         nav.navigate();
       },
       

--- a/userwidgets/Twitter.topHeader/modules/require/topHeaderControllerActions.js
+++ b/userwidgets/Twitter.topHeader/modules/require/topHeaderControllerActions.js
@@ -10,7 +10,7 @@ define({
     /** onClick defined for flxBackBtn **/
     AS_FlexContainer_cfcb9117e5864a23aa3148cb4a784eed: function AS_FlexContainer_cfcb9117e5864a23aa3148cb4a784eed(eventobject) {
         var self = this;
-        return self.navToLogin.call(this);
+        return self.navToPrevious.call(this);
     },
     /** onClick defined for flxSignUp **/
     AS_FlexContainer_de4780cecd544b3697811cb570e0fca9: function AS_FlexContainer_de4780cecd544b3697811cb570e0fca9(eventobject) {


### PR DESCRIPTION
Changed the back button to actually go to the previous form the user was on, no matter where they are in the interface and they click on the back button. (if the back button is visible on the header component).